### PR TITLE
Bump verible to v0.0-3824-g14eed6a0

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Sample `.pre-commit-config.yaml`:
 
 ```yaml
 - repo: https://github.com/imc-trading/verible-py.git
-    rev: v0.0-3426
+    rev: v0.0-3824
     hooks:
       - id: verible-verilog-lint
       - id: verible-verilog-format

--- a/scripts/bump-version
+++ b/scripts/bump-version
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+# Usage: ./scripts/bump-version <version> <hash>. For example:
+# ./scripts/bump-version 0.0-4023 gc1271a00
 set -Eeuo pipefail
 
 _version="${1:-\2}"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = verible_py
-version = v0.0-3426
+version = v0.0-3824
 description = Python wrapper around invoking verible (https://chipsalliance.github.io/verible/)
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -26,46 +26,46 @@ download_scripts =
     [verible-verilog-lint]
     group = verible-verilog-lint
     marker = sys_platform == "linux" and platform_machine == "x86_64"
-    url = https://github.com/chipsalliance/verible/releases/download/v0.0-3426-gac4a37d8/verible-v0.0-3426-gac4a37d8-linux-static-x86_64.tar.gz
-    sha256 = 7f159a3c9515db9077059aa0bba48d642c0a9700f0423395be96a4545c2a4371
+    url = https://github.com/chipsalliance/verible/releases/download/v0.0-3824-g14eed6a0/verible-v0.0-3824-g14eed6a0-linux-static-x86_64.tar.gz
+    sha256 = dc1daae341da824ee14800f21de0931974842b334e402a30ffe49cf6c7912e38
     extract = tar
-    extract_path = verible-v0.0-3426-gac4a37d8/bin/verible-verilog-lint
+    extract_path = verible-v0.0-3824-g14eed6a0/bin/verible-verilog-lint
     [verible-verilog-format]
     group = verible-verilog-format
     marker = sys_platform == "linux" and platform_machine == "x86_64"
-    url = https://github.com/chipsalliance/verible/releases/download/v0.0-3426-gac4a37d8/verible-v0.0-3426-gac4a37d8-linux-static-x86_64.tar.gz
-    sha256 = 7f159a3c9515db9077059aa0bba48d642c0a9700f0423395be96a4545c2a4371
+    url = https://github.com/chipsalliance/verible/releases/download/v0.0-3824-g14eed6a0/verible-v0.0-3824-g14eed6a0-linux-static-x86_64.tar.gz
+    sha256 = dc1daae341da824ee14800f21de0931974842b334e402a30ffe49cf6c7912e38
     extract = tar
-    extract_path = verible-v0.0-3426-gac4a37d8/bin/verible-verilog-format
+    extract_path = verible-v0.0-3824-g14eed6a0/bin/verible-verilog-format
     [verible-verilog-lint]
     group = verible-verilog-lint
     marker = sys_platform == "darwin" and platform_machine == "x86_64"
     marker = sys_platform == "darwin" and platform_machine == "arm64"
-    url = https://github.com/chipsalliance/verible/releases/download/v0.0-3426-gac4a37d8/verible-v0.0-3426-gac4a37d8-macOS.tar.gz
-    sha256 = 53f00e16e55ed902aa0574b96326b7e86939d903e6c8e35a534884e0efa220b3
+    url = https://github.com/chipsalliance/verible/releases/download/v0.0-3824-g14eed6a0/verible-v0.0-3824-g14eed6a0-macOS.tar.gz
+    sha256 = c3e4aeffeaceb9007e3619e16f92a5129d40b2a3e2c1124ff18565a881282643
     extract = tar
-    extract_path = verible-v0.0-3426-gac4a37d8-macOS/bin/verible-verilog-lint
+    extract_path = verible-v0.0-3824-g14eed6a0-macOS/bin/verible-verilog-lint
     [verible-verilog-format]
     group = verible-verilog-format
     marker = sys_platform == "darwin" and platform_machine == "x86_64"
     marker = sys_platform == "darwin" and platform_machine == "arm64"
-    url = https://github.com/chipsalliance/verible/releases/download/v0.0-3426-gac4a37d8/verible-v0.0-3426-gac4a37d8-macOS.tar.gz
-    sha256 = 53f00e16e55ed902aa0574b96326b7e86939d903e6c8e35a534884e0efa220b3
+    url = https://github.com/chipsalliance/verible/releases/download/v0.0-3824-g14eed6a0/verible-v0.0-3824-g14eed6a0-macOS.tar.gz
+    sha256 = c3e4aeffeaceb9007e3619e16f92a5129d40b2a3e2c1124ff18565a881282643
     extract = tar
-    extract_path = verible-v0.0-3426-gac4a37d8-macOS/bin/verible-verilog-format
+    extract_path = verible-v0.0-3824-g14eed6a0-macOS/bin/verible-verilog-format
     [verible-verilog-lint.exe]
     group = verible-verilog-lint
     marker = sys_platform == "win32" and platform_machine == "AMD64"
     marker = sys_platform == "cygwin" and platform_machine == "x86_64"
-    url = https://github.com/chipsalliance/verible/releases/download/v0.0-3426-gac4a37d8/verible-v0.0-3426-gac4a37d8-win64.zip
-    sha256 = 6cf4010496f73a75eabe5556b26724260dd1ec15f997b3b02b55d2e87a730ea6
+    url = https://github.com/chipsalliance/verible/releases/download/v0.0-3824-g14eed6a0/verible-v0.0-3824-g14eed6a0-win64.zip
+    sha256 = 6e31ed3e5644991a107d0fd3e3ec20e7eb64bd174b72c8d03d8f8b90786ea791
     extract = zip
-    extract_path = verible-v0.0-3426-gac4a37d8-win64/verible-verilog-lint.exe
+    extract_path = verible-v0.0-3824-g14eed6a0-win64/verible-verilog-lint.exe
     [verible-verilog-format.exe]
     group = verible-verilog-format
     marker = sys_platform == "win32" and platform_machine == "AMD64"
     marker = sys_platform == "cygwin" and platform_machine == "x86_64"
-    url = https://github.com/chipsalliance/verible/releases/download/v0.0-3426-gac4a37d8/verible-v0.0-3426-gac4a37d8-win64.zip
-    sha256 = 6cf4010496f73a75eabe5556b26724260dd1ec15f997b3b02b55d2e87a730ea6
+    url = https://github.com/chipsalliance/verible/releases/download/v0.0-3824-g14eed6a0/verible-v0.0-3824-g14eed6a0-win64.zip
+    sha256 = 6e31ed3e5644991a107d0fd3e3ec20e7eb64bd174b72c8d03d8f8b90786ea791
     extract = zip
-    extract_path = verible-v0.0-3426-gac4a37d8-win64/verible-verilog-format.exe
+    extract_path = verible-v0.0-3824-g14eed6a0-win64/verible-verilog-format.exe

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = verible_py
-version = v0.0-4023
+version = v0.0-4051
 description = Python wrapper around invoking verible (https://chipsalliance.github.io/verible/)
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -26,46 +26,46 @@ download_scripts =
     [verible-verilog-lint]
     group = verible-verilog-lint
     marker = sys_platform == "linux" and platform_machine == "x86_64"
-    url = https://github.com/chipsalliance/verible/releases/download/v0.0-4023-gc1271a00/verible-v0.0-4023-gc1271a00-linux-static-x86_64.tar.gz
-    sha256 = 30c20385956f52ef892cb58f7f816f9f9a9dc37a0432848a49c6d9aa3a72a8b7
+    url = https://github.com/chipsalliance/verible/releases/download/v0.0-4051-g9fdb4057/verible-v0.0-4051-g9fdb4057-linux-static-x86_64.tar.gz
+    sha256 = f52e5920ef63f70620a6086e09dea8bd778147cd7a9ff827bb7de5d6316b1754
     extract = tar
-    extract_path = verible-v0.0-4023-gc1271a00/bin/verible-verilog-lint
+    extract_path = verible-v0.0-4051-g9fdb4057/bin/verible-verilog-lint
     [verible-verilog-format]
     group = verible-verilog-format
     marker = sys_platform == "linux" and platform_machine == "x86_64"
-    url = https://github.com/chipsalliance/verible/releases/download/v0.0-4023-gc1271a00/verible-v0.0-4023-gc1271a00-linux-static-x86_64.tar.gz
-    sha256 = 30c20385956f52ef892cb58f7f816f9f9a9dc37a0432848a49c6d9aa3a72a8b7
+    url = https://github.com/chipsalliance/verible/releases/download/v0.0-4051-g9fdb4057/verible-v0.0-4051-g9fdb4057-linux-static-x86_64.tar.gz
+    sha256 = f52e5920ef63f70620a6086e09dea8bd778147cd7a9ff827bb7de5d6316b1754
     extract = tar
-    extract_path = verible-v0.0-4023-gc1271a00/bin/verible-verilog-format
+    extract_path = verible-v0.0-4051-g9fdb4057/bin/verible-verilog-format
     [verible-verilog-lint]
     group = verible-verilog-lint
     marker = sys_platform == "darwin" and platform_machine == "x86_64"
     marker = sys_platform == "darwin" and platform_machine == "arm64"
-    url = https://github.com/chipsalliance/verible/releases/download/v0.0-4023-gc1271a00/verible-v0.0-4023-gc1271a00-macOS.tar.gz
-    sha256 = 693c044b0cc3f5179363365f3bb001bbca0a9a395a24ed9f5e2689fe6d69d517
+    url = https://github.com/chipsalliance/verible/releases/download/v0.0-4051-g9fdb4057/verible-v0.0-4051-g9fdb4057-macOS.tar.gz
+    sha256 = 9ef92e9ad345285dd593763e10ca61c8532fcf47bbb6cf4448f9a9423882d662
     extract = tar
-    extract_path = verible-v0.0-4023-gc1271a00-macOS/bin/verible-verilog-lint
+    extract_path = verible-v0.0-4051-g9fdb4057-macOS/bin/verible-verilog-lint
     [verible-verilog-format]
     group = verible-verilog-format
     marker = sys_platform == "darwin" and platform_machine == "x86_64"
     marker = sys_platform == "darwin" and platform_machine == "arm64"
-    url = https://github.com/chipsalliance/verible/releases/download/v0.0-4023-gc1271a00/verible-v0.0-4023-gc1271a00-macOS.tar.gz
-    sha256 = 693c044b0cc3f5179363365f3bb001bbca0a9a395a24ed9f5e2689fe6d69d517
+    url = https://github.com/chipsalliance/verible/releases/download/v0.0-4051-g9fdb4057/verible-v0.0-4051-g9fdb4057-macOS.tar.gz
+    sha256 = 9ef92e9ad345285dd593763e10ca61c8532fcf47bbb6cf4448f9a9423882d662
     extract = tar
-    extract_path = verible-v0.0-4023-gc1271a00-macOS/bin/verible-verilog-format
+    extract_path = verible-v0.0-4051-g9fdb4057-macOS/bin/verible-verilog-format
     [verible-verilog-lint.exe]
     group = verible-verilog-lint
     marker = sys_platform == "win32" and platform_machine == "AMD64"
     marker = sys_platform == "cygwin" and platform_machine == "x86_64"
-    url = https://github.com/chipsalliance/verible/releases/download/v0.0-4023-gc1271a00/verible-v0.0-4023-gc1271a00-win64.zip
-    sha256 = 8984e84a218eb7f9f6e92493967ff22ea7dde86aabd2fe8beeed55aa24ad3a20
+    url = https://github.com/chipsalliance/verible/releases/download/v0.0-4051-g9fdb4057/verible-v0.0-4051-g9fdb4057-win64.zip
+    sha256 = 729aa244036da4a4f87bc026d33555456fc7f7be79778d983ebe9c893f4a0ca3
     extract = zip
-    extract_path = verible-v0.0-4023-gc1271a00-win64/verible-verilog-lint.exe
+    extract_path = verible-v0.0-4051-g9fdb4057-win64/verible-verilog-lint.exe
     [verible-verilog-format.exe]
     group = verible-verilog-format
     marker = sys_platform == "win32" and platform_machine == "AMD64"
     marker = sys_platform == "cygwin" and platform_machine == "x86_64"
-    url = https://github.com/chipsalliance/verible/releases/download/v0.0-4023-gc1271a00/verible-v0.0-4023-gc1271a00-win64.zip
-    sha256 = 8984e84a218eb7f9f6e92493967ff22ea7dde86aabd2fe8beeed55aa24ad3a20
+    url = https://github.com/chipsalliance/verible/releases/download/v0.0-4051-g9fdb4057/verible-v0.0-4051-g9fdb4057-win64.zip
+    sha256 = 729aa244036da4a4f87bc026d33555456fc7f7be79778d983ebe9c893f4a0ca3
     extract = zip
-    extract_path = verible-v0.0-4023-gc1271a00-win64/verible-verilog-format.exe
+    extract_path = verible-v0.0-4051-g9fdb4057-win64/verible-verilog-format.exe

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = verible_py
-version = v0.0-3824
+version = v0.0-3946
 description = Python wrapper around invoking verible (https://chipsalliance.github.io/verible/)
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -26,46 +26,46 @@ download_scripts =
     [verible-verilog-lint]
     group = verible-verilog-lint
     marker = sys_platform == "linux" and platform_machine == "x86_64"
-    url = https://github.com/chipsalliance/verible/releases/download/v0.0-3824-g14eed6a0/verible-v0.0-3824-g14eed6a0-linux-static-x86_64.tar.gz
-    sha256 = dc1daae341da824ee14800f21de0931974842b334e402a30ffe49cf6c7912e38
+    url = https://github.com/chipsalliance/verible/releases/download/v0.0-3946-g851d3ff4/verible-v0.0-3946-g851d3ff4-linux-static-x86_64.tar.gz
+    sha256 = be81036ab5a3d5d5ba4ee677ebf9a09665779c3bd99ffe2e161c5025beaa1f16
     extract = tar
-    extract_path = verible-v0.0-3824-g14eed6a0/bin/verible-verilog-lint
+    extract_path = verible-v0.0-3946-g851d3ff4/bin/verible-verilog-lint
     [verible-verilog-format]
     group = verible-verilog-format
     marker = sys_platform == "linux" and platform_machine == "x86_64"
-    url = https://github.com/chipsalliance/verible/releases/download/v0.0-3824-g14eed6a0/verible-v0.0-3824-g14eed6a0-linux-static-x86_64.tar.gz
-    sha256 = dc1daae341da824ee14800f21de0931974842b334e402a30ffe49cf6c7912e38
+    url = https://github.com/chipsalliance/verible/releases/download/v0.0-3946-g851d3ff4/verible-v0.0-3946-g851d3ff4-linux-static-x86_64.tar.gz
+    sha256 = be81036ab5a3d5d5ba4ee677ebf9a09665779c3bd99ffe2e161c5025beaa1f16
     extract = tar
-    extract_path = verible-v0.0-3824-g14eed6a0/bin/verible-verilog-format
+    extract_path = verible-v0.0-3946-g851d3ff4/bin/verible-verilog-format
     [verible-verilog-lint]
     group = verible-verilog-lint
     marker = sys_platform == "darwin" and platform_machine == "x86_64"
     marker = sys_platform == "darwin" and platform_machine == "arm64"
-    url = https://github.com/chipsalliance/verible/releases/download/v0.0-3824-g14eed6a0/verible-v0.0-3824-g14eed6a0-macOS.tar.gz
-    sha256 = c3e4aeffeaceb9007e3619e16f92a5129d40b2a3e2c1124ff18565a881282643
+    url = https://github.com/chipsalliance/verible/releases/download/v0.0-3946-g851d3ff4/verible-v0.0-3946-g851d3ff4-macOS.tar.gz
+    sha256 = fe2cb5668f0edc22caad44c83f9bc812061f5b9657573abdfd72d50a65ad32c4
     extract = tar
-    extract_path = verible-v0.0-3824-g14eed6a0-macOS/bin/verible-verilog-lint
+    extract_path = verible-v0.0-3946-g851d3ff4-macOS/bin/verible-verilog-lint
     [verible-verilog-format]
     group = verible-verilog-format
     marker = sys_platform == "darwin" and platform_machine == "x86_64"
     marker = sys_platform == "darwin" and platform_machine == "arm64"
-    url = https://github.com/chipsalliance/verible/releases/download/v0.0-3824-g14eed6a0/verible-v0.0-3824-g14eed6a0-macOS.tar.gz
-    sha256 = c3e4aeffeaceb9007e3619e16f92a5129d40b2a3e2c1124ff18565a881282643
+    url = https://github.com/chipsalliance/verible/releases/download/v0.0-3946-g851d3ff4/verible-v0.0-3946-g851d3ff4-macOS.tar.gz
+    sha256 = fe2cb5668f0edc22caad44c83f9bc812061f5b9657573abdfd72d50a65ad32c4
     extract = tar
-    extract_path = verible-v0.0-3824-g14eed6a0-macOS/bin/verible-verilog-format
+    extract_path = verible-v0.0-3946-g851d3ff4-macOS/bin/verible-verilog-format
     [verible-verilog-lint.exe]
     group = verible-verilog-lint
     marker = sys_platform == "win32" and platform_machine == "AMD64"
     marker = sys_platform == "cygwin" and platform_machine == "x86_64"
-    url = https://github.com/chipsalliance/verible/releases/download/v0.0-3824-g14eed6a0/verible-v0.0-3824-g14eed6a0-win64.zip
-    sha256 = 6e31ed3e5644991a107d0fd3e3ec20e7eb64bd174b72c8d03d8f8b90786ea791
+    url = https://github.com/chipsalliance/verible/releases/download/v0.0-3946-g851d3ff4/verible-v0.0-3946-g851d3ff4-win64.zip
+    sha256 = 22c4a85dab34537504f218e872ac6efbdca2f0ac0ad789cd98004af0fa1e1b21
     extract = zip
-    extract_path = verible-v0.0-3824-g14eed6a0-win64/verible-verilog-lint.exe
+    extract_path = verible-v0.0-3946-g851d3ff4-win64/verible-verilog-lint.exe
     [verible-verilog-format.exe]
     group = verible-verilog-format
     marker = sys_platform == "win32" and platform_machine == "AMD64"
     marker = sys_platform == "cygwin" and platform_machine == "x86_64"
-    url = https://github.com/chipsalliance/verible/releases/download/v0.0-3824-g14eed6a0/verible-v0.0-3824-g14eed6a0-win64.zip
-    sha256 = 6e31ed3e5644991a107d0fd3e3ec20e7eb64bd174b72c8d03d8f8b90786ea791
+    url = https://github.com/chipsalliance/verible/releases/download/v0.0-3946-g851d3ff4/verible-v0.0-3946-g851d3ff4-win64.zip
+    sha256 = 22c4a85dab34537504f218e872ac6efbdca2f0ac0ad789cd98004af0fa1e1b21
     extract = zip
-    extract_path = verible-v0.0-3824-g14eed6a0-win64/verible-verilog-format.exe
+    extract_path = verible-v0.0-3946-g851d3ff4-win64/verible-verilog-format.exe

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = verible_py
-version = v0.0-3946
+version = v0.0-4023
 description = Python wrapper around invoking verible (https://chipsalliance.github.io/verible/)
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -26,46 +26,46 @@ download_scripts =
     [verible-verilog-lint]
     group = verible-verilog-lint
     marker = sys_platform == "linux" and platform_machine == "x86_64"
-    url = https://github.com/chipsalliance/verible/releases/download/v0.0-3946-g851d3ff4/verible-v0.0-3946-g851d3ff4-linux-static-x86_64.tar.gz
-    sha256 = be81036ab5a3d5d5ba4ee677ebf9a09665779c3bd99ffe2e161c5025beaa1f16
+    url = https://github.com/chipsalliance/verible/releases/download/v0.0-4023-gc1271a00/verible-v0.0-4023-gc1271a00-linux-static-x86_64.tar.gz
+    sha256 = 30c20385956f52ef892cb58f7f816f9f9a9dc37a0432848a49c6d9aa3a72a8b7
     extract = tar
-    extract_path = verible-v0.0-3946-g851d3ff4/bin/verible-verilog-lint
+    extract_path = verible-v0.0-4023-gc1271a00/bin/verible-verilog-lint
     [verible-verilog-format]
     group = verible-verilog-format
     marker = sys_platform == "linux" and platform_machine == "x86_64"
-    url = https://github.com/chipsalliance/verible/releases/download/v0.0-3946-g851d3ff4/verible-v0.0-3946-g851d3ff4-linux-static-x86_64.tar.gz
-    sha256 = be81036ab5a3d5d5ba4ee677ebf9a09665779c3bd99ffe2e161c5025beaa1f16
+    url = https://github.com/chipsalliance/verible/releases/download/v0.0-4023-gc1271a00/verible-v0.0-4023-gc1271a00-linux-static-x86_64.tar.gz
+    sha256 = 30c20385956f52ef892cb58f7f816f9f9a9dc37a0432848a49c6d9aa3a72a8b7
     extract = tar
-    extract_path = verible-v0.0-3946-g851d3ff4/bin/verible-verilog-format
+    extract_path = verible-v0.0-4023-gc1271a00/bin/verible-verilog-format
     [verible-verilog-lint]
     group = verible-verilog-lint
     marker = sys_platform == "darwin" and platform_machine == "x86_64"
     marker = sys_platform == "darwin" and platform_machine == "arm64"
-    url = https://github.com/chipsalliance/verible/releases/download/v0.0-3946-g851d3ff4/verible-v0.0-3946-g851d3ff4-macOS.tar.gz
-    sha256 = fe2cb5668f0edc22caad44c83f9bc812061f5b9657573abdfd72d50a65ad32c4
+    url = https://github.com/chipsalliance/verible/releases/download/v0.0-4023-gc1271a00/verible-v0.0-4023-gc1271a00-macOS.tar.gz
+    sha256 = 693c044b0cc3f5179363365f3bb001bbca0a9a395a24ed9f5e2689fe6d69d517
     extract = tar
-    extract_path = verible-v0.0-3946-g851d3ff4-macOS/bin/verible-verilog-lint
+    extract_path = verible-v0.0-4023-gc1271a00-macOS/bin/verible-verilog-lint
     [verible-verilog-format]
     group = verible-verilog-format
     marker = sys_platform == "darwin" and platform_machine == "x86_64"
     marker = sys_platform == "darwin" and platform_machine == "arm64"
-    url = https://github.com/chipsalliance/verible/releases/download/v0.0-3946-g851d3ff4/verible-v0.0-3946-g851d3ff4-macOS.tar.gz
-    sha256 = fe2cb5668f0edc22caad44c83f9bc812061f5b9657573abdfd72d50a65ad32c4
+    url = https://github.com/chipsalliance/verible/releases/download/v0.0-4023-gc1271a00/verible-v0.0-4023-gc1271a00-macOS.tar.gz
+    sha256 = 693c044b0cc3f5179363365f3bb001bbca0a9a395a24ed9f5e2689fe6d69d517
     extract = tar
-    extract_path = verible-v0.0-3946-g851d3ff4-macOS/bin/verible-verilog-format
+    extract_path = verible-v0.0-4023-gc1271a00-macOS/bin/verible-verilog-format
     [verible-verilog-lint.exe]
     group = verible-verilog-lint
     marker = sys_platform == "win32" and platform_machine == "AMD64"
     marker = sys_platform == "cygwin" and platform_machine == "x86_64"
-    url = https://github.com/chipsalliance/verible/releases/download/v0.0-3946-g851d3ff4/verible-v0.0-3946-g851d3ff4-win64.zip
-    sha256 = 22c4a85dab34537504f218e872ac6efbdca2f0ac0ad789cd98004af0fa1e1b21
+    url = https://github.com/chipsalliance/verible/releases/download/v0.0-4023-gc1271a00/verible-v0.0-4023-gc1271a00-win64.zip
+    sha256 = 8984e84a218eb7f9f6e92493967ff22ea7dde86aabd2fe8beeed55aa24ad3a20
     extract = zip
-    extract_path = verible-v0.0-3946-g851d3ff4-win64/verible-verilog-lint.exe
+    extract_path = verible-v0.0-4023-gc1271a00-win64/verible-verilog-lint.exe
     [verible-verilog-format.exe]
     group = verible-verilog-format
     marker = sys_platform == "win32" and platform_machine == "AMD64"
     marker = sys_platform == "cygwin" and platform_machine == "x86_64"
-    url = https://github.com/chipsalliance/verible/releases/download/v0.0-3946-g851d3ff4/verible-v0.0-3946-g851d3ff4-win64.zip
-    sha256 = 22c4a85dab34537504f218e872ac6efbdca2f0ac0ad789cd98004af0fa1e1b21
+    url = https://github.com/chipsalliance/verible/releases/download/v0.0-4023-gc1271a00/verible-v0.0-4023-gc1271a00-win64.zip
+    sha256 = 8984e84a218eb7f9f6e92493967ff22ea7dde86aabd2fe8beeed55aa24ad3a20
     extract = zip
-    extract_path = verible-v0.0-3946-g851d3ff4-win64/verible-verilog-format.exe
+    extract_path = verible-v0.0-4023-gc1271a00-win64/verible-verilog-format.exe


### PR DESCRIPTION
Bump verible version to latest (v0.0-3824-g14eed6a0), released yesterday: https://github.com/chipsalliance/verible/releases/tag/v0.0-3824-g14eed6a0